### PR TITLE
moreFollows is not optional field

### DIFF
--- a/src/mms/iso_mms/server/mms_file_service.c
+++ b/src/mms/iso_mms/server/mms_file_service.c
@@ -568,8 +568,7 @@ createFileDirectoryResponse(uint32_t invokeId, ByteBuffer* response, char* direc
 
     bufPos += tempEncoded;
 
-    if (moreFollows)
-        bufPos = BerEncoder_encodeBoolean(0x81, moreFollows, buffer, bufPos);
+    bufPos = BerEncoder_encodeBoolean(0x81, moreFollows, buffer, bufPos);
 
     response->size = bufPos;
 }


### PR DESCRIPTION
from mms asn1 defs

FileRead-Response ::= SEQUENCE {
	fileData	[0] IMPLICIT OCTET STRING,
	moreFollows	[1] IMPLICIT BOOLEAN DEFAULT TRUE
	}
This patch makes it so the moreFollows field is always present. 

